### PR TITLE
Corrected relative include paths to the ogl_headers.h file that

### DIFF
--- a/include/sgct/CorrectionMesh.h
+++ b/include/sgct/CorrectionMesh.h
@@ -8,7 +8,7 @@
 #ifndef _CORRECTION_MESH_H_
 #define _CORRECTION_MESH_H_
 
-#include "sgct/ogl_headers.h"
+#include "ogl_headers.h"
 
 namespace sgct_core
 {

--- a/include/sgct/ScreenCapture.h
+++ b/include/sgct/ScreenCapture.h
@@ -8,7 +8,7 @@ For conditions of distribution and use, see copyright notice in sgct.h
 #ifndef _SCREEN_CAPTURE_H_
 #define _SCREEN_CAPTURE_H_
 
-#include "../include/sgct/ogl_headers.h"
+#include "ogl_headers.h"
 #include "Image.h"
 #include "helpers/SGCTCPPEleven.h"
 #include <string>


### PR DESCRIPTION
Corrected relative include paths to the ogl_headers.h file that resides in the same folder
