### PR TITLE
Aspect ratio tracked

### DIFF
--- a/include/sgct/BaseViewport.h
+++ b/include/sgct/BaseViewport.h
@@ -50,6 +50,8 @@ public:
     void calculateFrustum(const Frustum::FrustumMode &frustumMode, float near_clipping_plane, float far_clipping_plane);
     void calculateNonLinearFrustum(const Frustum::FrustumMode &frustumMode, float near_clipping_plane, float far_clipping_plane);
     void setViewPlaneCoordsUsingFOVs(float up, float down, float left, float right, glm::quat rot, float dist = 10.0f);
+    void setViewPlaneCoordsFromUnTransformedCoords(glm::vec3 untransformedCoords[3], glm::quat rot, bool verbose);
+    void updateFovToMatchAspectRatio(float oldRatio, float newRatio);
     
 protected:
     SGCTProjection mProjections[3];
@@ -64,6 +66,9 @@ protected:
     float mY;
     float mXSize;
     float mYSize;
+
+    glm::vec3 mUnTransformedViewPlaneCoords[3];
+    glm::quat  mRot;
 };
 
 }

--- a/include/sgct/SGCTProjectionPlane.h
+++ b/include/sgct/SGCTProjectionPlane.h
@@ -28,7 +28,7 @@ namespace sgct_core
         enum ProjectionPlaneCorner { LowerLeft = 0, UpperLeft, UpperRight };
 
         SGCTProjectionPlane();
-        void configure(tinyxml2::XMLElement * element);
+        void configure(tinyxml2::XMLElement * element, glm::vec3* initializedCornerPoints);
         void reset();
         void offset(glm::vec3 p);
 

--- a/src/apps/calibrator/run_PlanarProjection_trackedAspectRatio.bat
+++ b/src/apps/calibrator/run_PlanarProjection_trackedAspectRatio.bat
@@ -1,0 +1,1 @@
+calibrator.exe -tilt 0.0 -radius 5.5 -config single_PlanarProjection_tracked.xml

--- a/src/apps/calibrator/run_Projectionplane_trackedAspectRatio.bat
+++ b/src/apps/calibrator/run_Projectionplane_trackedAspectRatio.bat
@@ -1,0 +1,1 @@
+calibrator.exe -tilt 0.0 -radius 5.5 -config single_Projectionplane_tracked.xml

--- a/src/apps/calibrator/run_Projectionplane_unTtrackedAspectRatio.bat
+++ b/src/apps/calibrator/run_Projectionplane_unTtrackedAspectRatio.bat
@@ -1,0 +1,1 @@
+calibrator.exe -tilt 0.0 -radius 5.5 -config single_Projectionplane_unTracked.xml

--- a/src/apps/calibrator/single_PlanarProjection_tracked.xml
+++ b/src/apps/calibrator/single_PlanarProjection_tracked.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<Cluster masterAddress="127.0.0.1">
+	<Node ip="127.0.0.1" port="20400">
+		<Window fullscreen="false" numberOfSamples="1" fxaa="false" msaa="1">
+			<Stereo type="none" />
+			<Pos x="0" y="0" />
+			<Size x="640" y="360" />
+			<Viewport tracked="true">
+				<Pos x="0.0" y="0.0" />
+				<Size x="1.0" y="1.0" />
+				<PlanarProjection>
+                                        <FOV down="25.0" left="35.0" right="35.0" up="25.0" />
+					<Orientation heading="0.0" pitch="0.0" roll="0.0" />
+				</PlanarProjection>
+			</Viewport>
+		</Window>
+	</Node>
+	<User eyeSeparation="0.06">
+		<Pos x="0.0" y="0.0" z="0.0" />
+	</User>
+</Cluster>

--- a/src/apps/calibrator/single_Projectionplane_tracked.xml
+++ b/src/apps/calibrator/single_Projectionplane_tracked.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+<Cluster masterAddress="localhost">
+	<Node address="localhost" port="20401">
+		<Window fullScreen="false">
+			<!-- 16:9 aspect ratio -->
+			<Size x="640" y="360" />
+			<Viewport tracked="true">
+				<Pos x="0.0" y="0.0" />
+				<Size x="1.0" y="1.0" />
+				<Projectionplane>
+					<!-- Lower left -->
+					<Pos x="-1.778" y="-1.0" z="0.0" />
+					<!-- Upper left -->
+					<Pos x="-1.778" y="1.0" z="0.0" />
+					<!-- Upper right -->
+					<Pos x="1.778" y="1.0" z="0.0" />
+				</Projectionplane>
+			</Viewport>
+		</Window>
+	</Node>
+	<User eyeSeparation="0.06">
+		<Pos x="0.0" y="0.0" z="4.0" />
+	</User>
+</Cluster>

--- a/src/apps/calibrator/single_Projectionplane_unTracked.xml
+++ b/src/apps/calibrator/single_Projectionplane_unTracked.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+<Cluster masterAddress="localhost">
+	<Node address="localhost" port="20401">
+		<Window fullScreen="false">
+			<!-- 16:9 aspect ratio -->
+			<Size x="640" y="360" />
+			<Viewport>
+				<Pos x="0.0" y="0.0" />
+				<Size x="1.0" y="1.0" />
+				<Projectionplane>
+					<!-- Lower left -->
+					<Pos x="-1.778" y="-1.0" z="0.0" />
+					<!-- Upper left -->
+					<Pos x="-1.778" y="1.0" z="0.0" />
+					<!-- Upper right -->
+					<Pos x="1.778" y="1.0" z="0.0" />
+				</Projectionplane>
+			</Viewport>
+		</Window>
+	</Node>
+	<User eyeSeparation="0.06">
+		<Pos x="0.0" y="0.0" z="4.0" />
+	</User>
+</Cluster>

--- a/src/sgct/BaseViewport.cpp
+++ b/src/sgct/BaseViewport.cpp
@@ -121,38 +121,57 @@ void sgct_core::BaseViewport::calculateNonLinearFrustum(const sgct_core::Frustum
 
 void sgct_core::BaseViewport::setViewPlaneCoordsUsingFOVs(float up, float down, float left, float right, glm::quat rot, float dist)
 {
-    glm::vec3 unTransformedViewPlaneCoords[3];
+    mRot = rot;
 
-    unTransformedViewPlaneCoords[SGCTProjectionPlane::LowerLeft].x = dist * tanf(glm::radians<float>(left));
-    unTransformedViewPlaneCoords[SGCTProjectionPlane::LowerLeft].y = dist * tanf(glm::radians<float>(down));
-    unTransformedViewPlaneCoords[SGCTProjectionPlane::LowerLeft].z = -dist;
+    mUnTransformedViewPlaneCoords[SGCTProjectionPlane::LowerLeft].x = dist * tanf(glm::radians<float>(left));
+    mUnTransformedViewPlaneCoords[SGCTProjectionPlane::LowerLeft].y = dist * tanf(glm::radians<float>(down));
+    mUnTransformedViewPlaneCoords[SGCTProjectionPlane::LowerLeft].z = -dist;
 
-    unTransformedViewPlaneCoords[SGCTProjectionPlane::UpperLeft].x = dist * tanf(glm::radians<float>(left));
-    unTransformedViewPlaneCoords[SGCTProjectionPlane::UpperLeft].y = dist * tanf(glm::radians<float>(up));
-    unTransformedViewPlaneCoords[SGCTProjectionPlane::UpperLeft].z = -dist;
+    mUnTransformedViewPlaneCoords[SGCTProjectionPlane::UpperLeft].x = dist * tanf(glm::radians<float>(left));
+    mUnTransformedViewPlaneCoords[SGCTProjectionPlane::UpperLeft].y = dist * tanf(glm::radians<float>(up));
+    mUnTransformedViewPlaneCoords[SGCTProjectionPlane::UpperLeft].z = -dist;
 
-    unTransformedViewPlaneCoords[SGCTProjectionPlane::UpperRight].x = dist * tanf(glm::radians<float>(right));
-    unTransformedViewPlaneCoords[SGCTProjectionPlane::UpperRight].y = dist * tanf(glm::radians<float>(up));
-    unTransformedViewPlaneCoords[SGCTProjectionPlane::UpperRight].z = -dist;
+    mUnTransformedViewPlaneCoords[SGCTProjectionPlane::UpperRight].x = dist * tanf(glm::radians<float>(right));
+    mUnTransformedViewPlaneCoords[SGCTProjectionPlane::UpperRight].y = dist * tanf(glm::radians<float>(up));
+    mUnTransformedViewPlaneCoords[SGCTProjectionPlane::UpperRight].z = -dist;
 
+    setViewPlaneCoordsFromUnTransformedCoords(mUnTransformedViewPlaneCoords, rot, true);
+}
+
+void sgct_core::BaseViewport::setViewPlaneCoordsFromUnTransformedCoords(glm::vec3 untransformedCoords[3], glm::quat rot, bool verbose)
+{
     for (std::size_t i = 0; i < 3; i++)
         mProjectionPlane.setCoordinate(i, rot * unTransformedViewPlaneCoords[i]);
 
-    sgct::MessageHandler::instance()->print(sgct::MessageHandler::NOTIFY_DEBUG,
-        "Viewplane lower left coords: %f %f %f\n",
-        mProjectionPlane.getCoordinatePtr(SGCTProjectionPlane::LowerLeft)->x,
-        mProjectionPlane.getCoordinatePtr(SGCTProjectionPlane::LowerLeft)->y,
-        mProjectionPlane.getCoordinatePtr(SGCTProjectionPlane::LowerLeft)->z);
+    if (verbose) {
+        sgct::MessageHandler::instance()->print(sgct::MessageHandler::NOTIFY_DEBUG,
+            "Viewplane lower left coords: %f %f %f\n",
+            mProjectionPlane.getCoordinatePtr(SGCTProjectionPlane::LowerLeft)->x,
+            mProjectionPlane.getCoordinatePtr(SGCTProjectionPlane::LowerLeft)->y,
+            mProjectionPlane.getCoordinatePtr(SGCTProjectionPlane::LowerLeft)->z);
 
-    sgct::MessageHandler::instance()->print(sgct::MessageHandler::NOTIFY_DEBUG,
-        "Viewplane upper left coords: %f %f %f\n",
-        mProjectionPlane.getCoordinatePtr(SGCTProjectionPlane::UpperLeft)->x,
-        mProjectionPlane.getCoordinatePtr(SGCTProjectionPlane::UpperLeft)->y,
-        mProjectionPlane.getCoordinatePtr(SGCTProjectionPlane::UpperLeft)->z);
+        sgct::MessageHandler::instance()->print(sgct::MessageHandler::NOTIFY_DEBUG,
+            "Viewplane upper left coords: %f %f %f\n",
+            mProjectionPlane.getCoordinatePtr(SGCTProjectionPlane::UpperLeft)->x,
+            mProjectionPlane.getCoordinatePtr(SGCTProjectionPlane::UpperLeft)->y,
+            mProjectionPlane.getCoordinatePtr(SGCTProjectionPlane::UpperLeft)->z);
 
-    sgct::MessageHandler::instance()->print(sgct::MessageHandler::NOTIFY_DEBUG,
-        "Viewplane upper right coords: %f %f %f\n\n",
-        mProjectionPlane.getCoordinatePtr(SGCTProjectionPlane::UpperRight)->x,
-        mProjectionPlane.getCoordinatePtr(SGCTProjectionPlane::UpperRight)->y,
-        mProjectionPlane.getCoordinatePtr(SGCTProjectionPlane::UpperRight)->z);
+        sgct::MessageHandler::instance()->print(sgct::MessageHandler::NOTIFY_DEBUG,
+            "Viewplane upper right coords: %f %f %f\n\n",
+            mProjectionPlane.getCoordinatePtr(SGCTProjectionPlane::UpperRight)->x,
+            mProjectionPlane.getCoordinatePtr(SGCTProjectionPlane::UpperRight)->y,
+            mProjectionPlane.getCoordinatePtr(SGCTProjectionPlane::UpperRight)->z);
+    }
+}
+
+void sgct_core::BaseViewport::updateFovToMatchAspectRatio(float oldRatio, float newRatio)
+{
+    glm::vec3 cornerPts[3];
+    for (unsigned int cornerNum = (unsigned int)SGCTProjectionPlane::LowerLeft; cornerNum <= (unsigned int)SGCTProjectionPlane::UpperRight; ++cornerNum)
+    {
+        cornerPts[cornerNum].x = mUnTransformedViewPlaneCoords[cornerNum].x * newRatio / oldRatio;
+        cornerPts[cornerNum].y = mUnTransformedViewPlaneCoords[cornerNum].y;
+        cornerPts[cornerNum].z = mUnTransformedViewPlaneCoords[cornerNum].z;
+    }
+    setViewPlaneCoordsFromUnTransformedCoords(cornerPts, mRot, false);
 }

--- a/src/sgct/BaseViewport.cpp
+++ b/src/sgct/BaseViewport.cpp
@@ -141,7 +141,7 @@ void sgct_core::BaseViewport::setViewPlaneCoordsUsingFOVs(float up, float down, 
 void sgct_core::BaseViewport::setViewPlaneCoordsFromUnTransformedCoords(glm::vec3 untransformedCoords[3], glm::quat rot, bool verbose)
 {
     for (std::size_t i = 0; i < 3; i++)
-        mProjectionPlane.setCoordinate(i, rot * unTransformedViewPlaneCoords[i]);
+        mProjectionPlane.setCoordinate(i, rot * untransformedCoords[i]);
 
     if (verbose) {
         sgct::MessageHandler::instance()->print(sgct::MessageHandler::NOTIFY_DEBUG,

--- a/src/sgct/SGCTProjectionPlane.cpp
+++ b/src/sgct/SGCTProjectionPlane.cpp
@@ -13,7 +13,8 @@ sgct_core::SGCTProjectionPlane::SGCTProjectionPlane()
     reset();
 }
 
-void sgct_core::SGCTProjectionPlane::configure(tinyxml2::XMLElement * element)
+void sgct_core::SGCTProjectionPlane::configure(tinyxml2::XMLElement * element,
+                                               glm::vec3* initializedCornerPoints)
 {
     const char * val;
     std::size_t i = 0;
@@ -41,6 +42,10 @@ void sgct_core::SGCTProjectionPlane::configure(tinyxml2::XMLElement * element)
                     tmpVec.x, tmpVec.y, tmpVec.z, i % 3);
 
                 setCoordinate(i % 3, tmpVec);
+                //Write this to initializedCornerPoints so caller knows initial corner values
+                initializedCornerPoints[i].x = tmpVec.x;
+                initializedCornerPoints[i].y = tmpVec.y;
+                initializedCornerPoints[i].z = tmpVec.z;
                 i++;
             }
             else

--- a/src/sgct/SGCTWindow.cpp
+++ b/src/sgct/SGCTWindow.cpp
@@ -491,8 +491,14 @@ void sgct::SGCTWindow::setWindowResolution(const int x, const int y)
 {
     mWindowRes[0] = x;
     mWindowRes[1] = y;
-    mAspectRatio = static_cast<float>( x ) /
-            static_cast<float>( y );
+    float newAspectRatio = static_cast<float>( x ) / static_cast<float>( y );
+
+    //Set field of view of each of this window's viewports to match new aspect ratio, adjusting only the horizontal (x) values
+    for (std::size_t j = 0; j < getNumberOfViewports(); ++j)
+    {
+        sgct_core::Viewport* vpPtr = getViewport(j);
+        vpPtr->updateFovToMatchAspectRatio(mAspectRatio, newAspectRatio);
+    }
 
 	//redraw window
 	if (mWindowHandle)

--- a/src/sgct/Viewport.cpp
+++ b/src/sgct/Viewport.cpp
@@ -142,7 +142,7 @@ void sgct_core::Viewport::configure(tinyxml2::XMLElement * element)
 		}
 		else if (strcmp("Viewplane", val) == 0 || strcmp("Projectionplane", val) == 0)
         {
-            mProjectionPlane.configure(subElement);
+            mProjectionPlane.configure(subElement, mUnTransformedViewPlaneCoords);	
         }
 
         //iterate


### PR DESCRIPTION
Added feature that automatically updates the frustum field of view of a window if it is resized, in order to preserve the aspect ratio of the window's resized dimensions. This works for `PlanarProjection`, `Projectionplane`, or `Viewplane`. Must have the **tracked** attribute enabled for this feature to work.