### PR TITLE
Feature to ignore reported monitor resolution if resolution is specified in config

### DIFF
--- a/include/sgct/SGCTWindow.h
+++ b/include/sgct/SGCTWindow.h
@@ -96,6 +96,8 @@ public:
     const bool &        isVisible() const;
     const bool &        isRenderingWhileHidden() const;
     const bool &        isFixResolution() const;
+    const bool &        isWindowResolutionSet() const;
+
     bool                isStereo() const;
     bool                isWindowResized() const;
     static inline bool    isBarrierActive() { return mBarrier; }
@@ -236,6 +238,7 @@ private:
     bool mFocused;
     bool mIconified;
     bool mUseFixResolution;
+    bool mIsWindowResSet;
     bool mAllowCapture;
     static bool mUseSwapGroups;
     static bool mBarrier;

--- a/src/sgct/SGCTWindow.cpp
+++ b/src/sgct/SGCTWindow.cpp
@@ -47,6 +47,7 @@ sgct::SGCTWindow::SGCTWindow(int id)
     mCallDraw3DFunction = true;
     mCopyPreviousWindowToCurrentWindow = false;
     mUseFixResolution = false;
+    mIsWindowResSet = false;
     mUseQuadBuffer = false;
     mFullScreen = false;
     mFloating = false;
@@ -583,6 +584,8 @@ void sgct::SGCTWindow::initWindowResolution(const int x, const int y)
     mAspectRatio = static_cast<float>( x ) /
             static_cast<float>( y );
 
+    mIsWindowResSet = true;
+
     if( !mUseFixResolution )
     {
         mFramebufferResolution[0] = x;
@@ -713,6 +716,14 @@ const bool & sgct::SGCTWindow::isRenderingWhileHidden() const
 const bool & sgct::SGCTWindow::isFixResolution() const
 {
     return mUseFixResolution;
+}
+
+/*!
+\returns If the window resolution was set in configuration file this function returns true.
+*/
+const bool & sgct::SGCTWindow::isWindowResolutionSet() const
+{
+    return mIsWindowResSet;
 }
 
 /*!
@@ -940,9 +951,11 @@ bool sgct::SGCTWindow::openWindow(GLFWwindow* share, size_t lastWindowIdx)
                     mId, mMonitorIndex, count);
         }
 
-        const GLFWvidmode* currentMode = glfwGetVideoMode(mMonitor);
-        mWindowRes[0] = currentMode->width;
-        mWindowRes[1] = currentMode->height;
+        if( !mIsWindowResSet ) {
+            const GLFWvidmode* currentMode = glfwGetVideoMode(mMonitor);
+            mWindowRes[0] = currentMode->width;
+            mWindowRes[1] = currentMode->height;
+        }
     }
 
     mWindowHandle = glfwCreateWindow(mWindowRes[0], mWindowRes[1], "SGCT", mMonitor, share);


### PR DESCRIPTION
With respect to output resolution, SGCT currently defers to what the monitor reports (the glfwGetVideoMode( ) call). This change would ignore that resolution and just use the resolution specified in the SGCT configuration, as long as a resolution is specified.
The reason for doing this was problems encountered in a few dome installations where the desired resolution wasn't being used by the projector. I assume that this occurred because the Windows OS was configured to use a different display resolution than the desired resolution, and the OpenSpace fullscreen window resolution was forced to use this rather than what was specified in the SGCT config file.

I'm unsure about how this could affect other use cases of SGCT, hopefully someone with more SGCT experience can evaluate this change with that in mind. I'm also unsure about the pre-existing boolean `mUseFixResolution` and if the added boolean `mIsWindowResSet` does the same thing.